### PR TITLE
copy your ec2 key to bastion home/ubuntu/.ssh/bosh.pem

### DIFF
--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1817,6 +1817,15 @@ resource "aws_instance" "bastion" {
         private_key = "${file("${var.aws_key_file}")}"
     }
   }
+  provisioner "file" {
+    source = "${var.aws_key_file}"
+    destination = "/home/ubuntu/.ssh/bosh.pem"
+    connection {
+        type = "ssh"
+        user = "ubuntu"
+        private_key = "${file("${var.aws_key_file}")}"
+    }
+  }
 }
 output "box.bastion.public" {
   value = "${aws_instance.bastion.public_ip}"


### PR DESCRIPTION
This only happen when you bootstrap new instance. 
The  following information from HashiCorp explains why.

>Provisioners are run only when a resource is created. They are not a replacement for configuration management and changing the software of an already-running server, and are instead just meant as a way to bootstrap a server. For configuration management, you should use Terraform provisioning to invoke a real configuration management solution.