### PR TITLE
Create CNAME for cf-ssh-elb when aws_route53_<env>_enabled = 1

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -2941,7 +2941,7 @@ As a quick pre-flight check, run `make manifest` to compile your Terraform plan.
 $ make deploy
 ```
 
-From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add a CNAME record that maps the domain name to the ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
+From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add two CNAME records, one that maps the domain-name to the CF-ELB endpoint and one that maps the ssh.domain-name to the CF-SSH-ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
 
 ```
 aws_route53_staging_enabled = "1"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -59,7 +59,7 @@ variable "aws_route53_prod_hosted_zone_id"    { default = "" } # PROD Hosted Zon
 #
 # The username to log into the nat box is `ec2-user'
 #
-# The regions, in order, are: N Virginia, N California, 
+# The regions, in order, are: N Virginia, N California,
 #   Oregon, Ireland, Frankfurt, Tokyo, Seoul, Singapore,
 #   Sydney, Mumbai, and Sao Paulo.
 
@@ -1858,6 +1858,14 @@ resource "aws_route53_record" "dev-cf-cname" {
    ttl     = "300"
    records = ["${aws_elb.dev-cf-elb.dns_name}"]
 }
+resource "aws_route53_record" "dev-cf-ssh-cname" {
+   count   = "${var.aws_route53_dev_enabled}"
+   zone_id = "${var.aws_route53_dev_hosted_zone_id}"
+   name    = "ssh.dev"
+   type    = "CNAME"
+   ttl     = "300"
+   records = ["${aws_elb.dev-cf-ssh-elb.dns_name}"]
+}
 
 ###############################################################
 # STAGING-CF-ROUTE53 Route53 CNAME
@@ -1870,6 +1878,14 @@ resource "aws_route53_record" "staging-cf-cname" {
    ttl     = "300"
    records = ["${aws_elb.staging-cf-elb.dns_name}"]
 }
+resource "aws_route53_record" "staging-cf-ssh-cname" {
+   count   = "${var.aws_route53_staging_enabled}"
+   zone_id = "${var.aws_route53_staging_hosted_zone_id}"
+   name    = "ssh.staging"
+   type    = "CNAME"
+   ttl     = "300"
+   records = ["${aws_elb.staging-cf-ssh-elb.dns_name}"]
+}
 
 ###############################################################
 # PROD-CF-ROUTE53 Route53 CNAME
@@ -1881,6 +1897,14 @@ resource "aws_route53_record" "prod-cf-cname" {
    type    = "CNAME"
    ttl     = "300"
    records = ["${aws_elb.prod-cf-elb.dns_name}"]
+}
+resource "aws_route53_record" "prod-cf-ssh-cname" {
+   count   = "${var.aws_route53_prod_enabled}"
+   zone_id = "${var.aws_route53_prod_hosted_zone_id}"
+   name    = "ssh.prod"
+   type    = "CNAME"
+   ttl     = "300"
+   records = ["${aws_elb.prod-cf-ssh-elb.dns_name}"]
 }
 
 


### PR DESCRIPTION
- This will also allow you to actually run `cf ssh <app-name>`.