### PR TITLE
Change the source files so they match the AWS walkthrough

### DIFF
--- a/walkthrough/.build/alpha_boshlite_deploy.md
+++ b/walkthrough/.build/alpha_boshlite_deploy.md
@@ -44,39 +44,3 @@ Duration	00:03:11
 
 Deployed `(( insert_parameter site.name ))-alpha-bosh-lite' to `(( insert_parameter site.name ))-proto-bosh'
 ```
-
-Now we can verify the deployment and set up our `bosh` CLI target:
-
-```
-# grab the admin password for the bosh-lite
-$ safe get secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
---- # secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
-password: YOUR-PASSWORD-WILL-BE-HERE
-
-
-$ bosh target https://10.4.1.80:25555 alpha
-Target set to `(( insert_parameter site.name ))-alpha-bosh-lite'
-Your username: admin
-Enter password:
-Logged in as `admin'
-$ bosh status
-Config
-             ~/.bosh_config
-
- Director
-   Name       (( insert_parameter site.name ))-alpha-bosh-lite
-     URL        https://10.4.1.80:25555
-   Version    1.3232.2.0 (00000000)
-     User       admin
-   UUID       d0a12392-f1df-4394-99d1-2c6ce376f821
-     CPI        vsphere_cpi
-   dns        disabled
-     compiled_package_cache disabled
-   snapshots  disabled
-
-   Deployment
-     not set
-```
-
-Tadaaa! Time to commit all the changes to deployment repo, and push to where we're storing
-them long-term.

--- a/walkthrough/.build/alpha_boshlite_target.md
+++ b/walkthrough/.build/alpha_boshlite_target.md
@@ -1,0 +1,35 @@
+Now we can verify the deployment and set up our `bosh` CLI target:
+
+```
+# grab the admin password for the bosh-lite
+$ safe get secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
+--- # secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
+password: YOUR-PASSWORD-WILL-BE-HERE
+
+
+$ bosh target https://10.4.1.80:25555 alpha
+Target set to `(( insert_parameter site.name ))-alpha-bosh-lite'
+Your username: admin
+Enter password:
+Logged in as `admin'
+$ bosh status
+Config
+             ~/.bosh_config
+
+ Director
+   Name       (( insert_parameter site.name ))-alpha-bosh-lite
+     URL        https://10.4.1.80:25555
+   Version    1.3232.2.0 (00000000)
+     User       admin
+   UUID       d0a12392-f1df-4394-99d1-2c6ce376f821
+     CPI        vsphere_cpi
+   dns        disabled
+     compiled_package_cache disabled
+   snapshots  disabled
+
+   Deployment
+     not set
+```
+
+Tadaaa! Time to commit all the changes to deployment repo, and push to where we're storing
+them long-term.

--- a/walkthrough/.build/aws.md.out
+++ b/walkthrough/.build/aws.md.out
@@ -8,7 +8,7 @@ generate the underlying cloud infrastructure, then use Terraform to prepare a ba
 host.
 
 From this bastion, we setup a special BOSH Director we call the **proto-BOSH**
-server where software like Vault, Concourse, Bolo and SHEILD are setup in order
+server where software like Vault, Concourse, Bolo and SHIELD are setup in order
 to give each of the environments created after the **proto-BOSH** key benefits of:
 
 * Secure Credential Storage
@@ -36,7 +36,7 @@ Now it's time to setup the credentials.
 ## Setup Credentials
 
 So you've got an AWS account right?  Cause otherwise let me interest you in
-another guide like our OpenStack, Azure or vSphere, etc.  j/k  
+another guide like our OpenStack, Azure or vSphere, etc.  j/k
 
 To begin, let's login to [Amazon Web Services][aws] and prepare the necessary
 credentials and resources needed.
@@ -143,7 +143,7 @@ to your Downloads folder.  Also `chmod 0600` the `*.pem` file.
 
 3. Decide where you want this file to be.  All `*.pem` files are ignored in the
 codex repository.  So you can either move this file to the same folder as
-`CODEX_ROOT/tefrraform/aws` or move it to a place you keep SSH keys and use the
+`CODEX_ROOT/terraform/aws` or move it to a place you keep SSH keys and use the
 full path to the `*.pem` file in your `aws.tfvars` for the `aws_key_file`
 variable name.
 
@@ -289,7 +289,7 @@ box.nat.public        = 52.41.225.204
 
 * In the AWS Console, go to Services > EC2.  In the dashboard each of the
 **Resources** are listed.  Find the _Running Instances_ click on it and locate
-the bastion.  The _Public IP_ is an attribute in the _Decription_ tab.
+the bastion.  The _Public IP_ is an attribute in the _Description_ tab.
 
 ### Connect to Bastion
 
@@ -1675,7 +1675,7 @@ ensuring that you get no errors (no output is a good sign).
 
 Then, you can deploy to your BOSH Director via `make deploy`.
 
-Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the Gnossis web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
+Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the [Gnossis](https://github.com/bolo/gnossis) web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
 
 One way of doing it is using ngrok, go to [ngrok Downloads] [ngrok-download] page and download the right version to your `bolo/0` VM, unzip it and run `./ngrok http 80`, it will output something like this:
 
@@ -1830,7 +1830,7 @@ Running env setup hook: ~/ops/concourse-deployments/.env_hooks/00_confirm_vault
 
 Use this Vault for storing deployment credentials?  [yes or no] yes
 Running env setup hook: ~/ops/concourse-deployments/.env_hooks/gen_creds
-Generating credentials for Concource CI
+Generating credentials for Concourse CI
 Created environment aws/proto:
 ~/ops/concourse-deployments/us-west-2/proto
 ├── cloudfoundry.yml
@@ -2193,6 +2193,9 @@ Duration	00:03:11
 
 Deployed `us-west-2-alpha-bosh-lite' to `us-west-2-proto-bosh'
 ```
+
+
+**NOTE**: If deploying a bosh-release (BOSH in this case) fails from the proto-BOSH to a child environment (different subnet), you might be having [this issue](https://github.com/starkandwayne/codex/issues/64) with a too strict AWS Network ACL (`<vpc name>-hardened`). BOSH will fail with errors such as: `Error 450002: Timed out pinging to ... after 600 seconds`.
 
 Now we can verify the deployment and set up our `bosh` CLI target:
 
@@ -2775,7 +2778,7 @@ Makefile:22: recipe for target 'manifest' failed
 make: *** [manifest] Error 5
 ```
 
-Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those:
+Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those (no need to create the blobstore S3 buckets yourself):
 
 ```
 $ cat properties.yml
@@ -2898,7 +2901,7 @@ Created out/CertAuth.crl
 Then create the certificates for your domain:
 
 ```
-$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.apps.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
+$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.run.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
 
 Enter passphrase (empty for no passphrase):
 
@@ -2941,7 +2944,7 @@ As a quick pre-flight check, run `make manifest` to compile your Terraform plan.
 $ make deploy
 ```
 
-From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add a CNAME record that maps the domain name to the ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
+From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add two CNAME records, one that maps the domain-name to the CF-ELB endpoint and one that maps the ssh.domain-name to the CF-SSH-ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
 
 ```
 aws_route53_staging_enabled = "1"
@@ -3151,7 +3154,7 @@ meta:
   dns: [10.4.0.2]
   elbs: [xxxxxx-staging-cf-elb] # <- ELB name
   ssh_elbs: [xxxxxx-staging-cf-ssh-elb] # <- SSH ELB name
-  router_security_group: [wide-open]
+  router_security_groups: [wide-open]
   security_groups: [wide-open]
 
 networks:
@@ -3316,7 +3319,7 @@ cf target -s test
 
 ```
 
-Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  rego on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
+Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  repo on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
 
 Your `cf push` command may fail like this:
 

--- a/walkthrough/.build/aws/walkthrough.md
+++ b/walkthrough/.build/aws/walkthrough.md
@@ -4,7 +4,7 @@
 ## Setup Credentials
 
 So you've got an AWS account right?  Cause otherwise let me interest you in
-another guide like our OpenStack, Azure or vSphere, etc.  j/k  
+another guide like our OpenStack, Azure or vSphere, etc.  j/k
 
 To begin, let's login to [Amazon Web Services][aws] and prepare the necessary
 credentials and resources needed.
@@ -111,7 +111,7 @@ to your Downloads folder.  Also `chmod 0600` the `*.pem` file.
 
 3. Decide where you want this file to be.  All `*.pem` files are ignored in the
 codex repository.  So you can either move this file to the same folder as
-`CODEX_ROOT/tefrraform/aws` or move it to a place you keep SSH keys and use the
+`CODEX_ROOT/terraform/aws` or move it to a place you keep SSH keys and use the
 full path to the `*.pem` file in your `aws.tfvars` for the `aws_key_file`
 variable name.
 
@@ -234,7 +234,7 @@ begin the teardown.  The second will shutdown the background process.
 (( insert_file bastion_intro.md ))
 * In the AWS Console, go to Services > EC2.  In the dashboard each of the
 **Resources** are listed.  Find the _Running Instances_ click on it and locate
-the bastion.  The _Public IP_ is an attribute in the _Decription_ tab.
+the bastion.  The _Public IP_ is an attribute in the _Description_ tab.
 
 ### Connect to Bastion
 
@@ -900,6 +900,10 @@ meta:
 ```
 
 (( insert_file alpha_boshlite_deploy.md ))
+
+**NOTE**: If deploying a bosh-release (BOSH in this case) fails from the proto-BOSH to a child environment (different subnet), you might be having [this issue](https://github.com/starkandwayne/codex/issues/64) with a too strict AWS Network ACL (`<vpc name>-hardened`). BOSH will fail with errors such as: `Error 450002: Timed out pinging to ... after 600 seconds`.
+
+(( insert_file alpha_boshlite_target.md ))
 (( insert_file alpha_cf.md ))
 (( insert_file beta_bosh_intro.md ))
 Let's try to deploy now, and see what information still needs to be resolved:
@@ -1077,7 +1081,7 @@ Makefile:22: recipe for target 'manifest' failed
 make: *** [manifest] Error 5
 ```
 
-Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those:
+Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those (no need to create the blobstore S3 buckets yourself):
 
 ```
 $ cat properties.yml
@@ -1131,7 +1135,7 @@ $ make deploy
 
 **TODO:** Create the `ccdb`,`uaadb` and `diegodb` databases inside the RDS Instance.
 
-We will manually create uaadb, ccdb and diegodb for now. First, connect to your PostgreSql database using the following command.
+We will manually create uaadb, ccdb and diegodb for now. First, connect to your PostgreSQL database using the following command.
 
 ```
 psql postgres://cfdbadmin:your_password@your_rds_instance_endpoint:5432/postgres
@@ -1195,7 +1199,7 @@ As a quick pre-flight check, run `make manifest` to compile your Terraform plan.
 $ make deploy
 ```
 
-From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add a CNAME record that maps the domain name to the ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
+From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add two CNAME records, one that maps the domain-name to the CF-ELB endpoint and one that maps the ssh.domain-name to the CF-SSH-ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
 
 ```
 aws_route53_staging_enabled = "1"
@@ -1395,7 +1399,7 @@ meta:
   dns: [10.4.0.2]
   elbs: [xxxxxx-staging-cf-elb] # <- ELB name
   ssh_elbs: [xxxxxx-staging-cf-ssh-elb] # <- SSH ELB name
-  router_security_group: [wide-open]
+  router_security_groups: [wide-open]
   security_groups: [wide-open]
 
 networks:

--- a/walkthrough/.build/beta_cf_cacert.md
+++ b/walkthrough/.build/beta_cf_cacert.md
@@ -18,7 +18,7 @@ Created out/CertAuth.crl
 Then create the certificates for your domain:
 
 ```
-$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.apps.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
+$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.run.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
 
 Enter passphrase (empty for no passphrase):
 

--- a/walkthrough/.build/beta_cf_push_app.md
+++ b/walkthrough/.build/beta_cf_push_app.md
@@ -12,7 +12,7 @@ cf target -s test
 
 ```
 
-Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  rego on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
+Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  repo on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
 
 Your `cf push` command may fail like this:
 

--- a/walkthrough/.build/bolo_test.md
+++ b/walkthrough/.build/bolo_test.md
@@ -3,7 +3,7 @@ ensuring that you get no errors (no output is a good sign).
 
 Then, you can deploy to your BOSH Director via `make deploy`.
 
-Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the Gnossis web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
+Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the [Gnossis](https://github.com/bolo/gnossis) web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
 
 One way of doing it is using ngrok, go to [ngrok Downloads] [ngrok-download] page and download the right version to your `bolo/0` VM, unzip it and run `./ngrok http 80`, it will output something like this:
 

--- a/walkthrough/.build/concourse_intro.md
+++ b/walkthrough/.build/concourse_intro.md
@@ -52,7 +52,7 @@ Running env setup hook: ~/ops/concourse-deployments/.env_hooks/00_confirm_vault
 
 Use this Vault for storing deployment credentials?  [yes or no] yes
 Running env setup hook: ~/ops/concourse-deployments/.env_hooks/gen_creds
-Generating credentials for Concource CI
+Generating credentials for Concourse CI
 Created environment (( insert_parameter template_name ))/proto:
 ~/ops/concourse-deployments/(( insert_parameter site.name ))/proto
 ├── cloudfoundry.yml

--- a/walkthrough/.build/overview.md
+++ b/walkthrough/.build/overview.md
@@ -6,7 +6,7 @@ generate the underlying cloud infrastructure, then use Terraform to prepare a ba
 host.
 
 From this bastion, we setup a special BOSH Director we call the **proto-BOSH**
-server where software like Vault, Concourse, Bolo and SHEILD are setup in order
+server where software like Vault, Concourse, Bolo and SHIELD are setup in order
 to give each of the environments created after the **proto-BOSH** key benefits of:
 
 * Secure Credential Storage

--- a/walkthrough/alpha_boshlite_deploy.md
+++ b/walkthrough/alpha_boshlite_deploy.md
@@ -44,39 +44,3 @@ Duration	00:03:11
 
 Deployed `(( insert_parameter site.name ))-alpha-bosh-lite' to `(( insert_parameter site.name ))-proto-bosh'
 ```
-
-Now we can verify the deployment and set up our `bosh` CLI target:
-
-```
-# grab the admin password for the bosh-lite
-$ safe get secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
---- # secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
-password: YOUR-PASSWORD-WILL-BE-HERE
-
-
-$ bosh target https://10.4.1.80:25555 alpha
-Target set to `(( insert_parameter site.name ))-alpha-bosh-lite'
-Your username: admin
-Enter password:
-Logged in as `admin'
-$ bosh status
-Config
-             ~/.bosh_config
-
- Director
-   Name       (( insert_parameter site.name ))-alpha-bosh-lite
-     URL        https://10.4.1.80:25555
-   Version    1.3232.2.0 (00000000)
-     User       admin
-   UUID       d0a12392-f1df-4394-99d1-2c6ce376f821
-     CPI        vsphere_cpi
-   dns        disabled
-     compiled_package_cache disabled
-   snapshots  disabled
-
-   Deployment
-     not set
-```
-
-Tadaaa! Time to commit all the changes to deployment repo, and push to where we're storing
-them long-term.

--- a/walkthrough/alpha_boshlite_target.md
+++ b/walkthrough/alpha_boshlite_target.md
@@ -1,0 +1,35 @@
+Now we can verify the deployment and set up our `bosh` CLI target:
+
+```
+# grab the admin password for the bosh-lite
+$ safe get secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
+--- # secret/(( insert_parameter site.name ))/alpha/bosh-lite/users/admin
+password: YOUR-PASSWORD-WILL-BE-HERE
+
+
+$ bosh target https://10.4.1.80:25555 alpha
+Target set to `(( insert_parameter site.name ))-alpha-bosh-lite'
+Your username: admin
+Enter password:
+Logged in as `admin'
+$ bosh status
+Config
+             ~/.bosh_config
+
+ Director
+   Name       (( insert_parameter site.name ))-alpha-bosh-lite
+     URL        https://10.4.1.80:25555
+   Version    1.3232.2.0 (00000000)
+     User       admin
+   UUID       d0a12392-f1df-4394-99d1-2c6ce376f821
+     CPI        vsphere_cpi
+   dns        disabled
+     compiled_package_cache disabled
+   snapshots  disabled
+
+   Deployment
+     not set
+```
+
+Tadaaa! Time to commit all the changes to deployment repo, and push to where we're storing
+them long-term.

--- a/walkthrough/aws/walkthrough.md
+++ b/walkthrough/aws/walkthrough.md
@@ -4,7 +4,7 @@
 ## Setup Credentials
 
 So you've got an AWS account right?  Cause otherwise let me interest you in
-another guide like our OpenStack, Azure or vSphere, etc.  j/k  
+another guide like our OpenStack, Azure or vSphere, etc.  j/k
 
 To begin, let's login to [Amazon Web Services][aws] and prepare the necessary
 credentials and resources needed.
@@ -111,7 +111,7 @@ to your Downloads folder.  Also `chmod 0600` the `*.pem` file.
 
 3. Decide where you want this file to be.  All `*.pem` files are ignored in the
 codex repository.  So you can either move this file to the same folder as
-`CODEX_ROOT/tefrraform/aws` or move it to a place you keep SSH keys and use the
+`CODEX_ROOT/terraform/aws` or move it to a place you keep SSH keys and use the
 full path to the `*.pem` file in your `aws.tfvars` for the `aws_key_file`
 variable name.
 
@@ -234,7 +234,7 @@ begin the teardown.  The second will shutdown the background process.
 (( insert_file bastion_intro.md ))
 * In the AWS Console, go to Services > EC2.  In the dashboard each of the
 **Resources** are listed.  Find the _Running Instances_ click on it and locate
-the bastion.  The _Public IP_ is an attribute in the _Decription_ tab.
+the bastion.  The _Public IP_ is an attribute in the _Description_ tab.
 
 ### Connect to Bastion
 
@@ -900,6 +900,10 @@ meta:
 ```
 
 (( insert_file alpha_boshlite_deploy.md ))
+
+**NOTE**: If deploying a bosh-release (BOSH in this case) fails from the proto-BOSH to a child environment (different subnet), you might be having [this issue](https://github.com/starkandwayne/codex/issues/64) with a too strict AWS Network ACL (`<vpc name>-hardened`). BOSH will fail with errors such as: `Error 450002: Timed out pinging to ... after 600 seconds`.
+
+(( insert_file alpha_boshlite_target.md ))
 (( insert_file alpha_cf.md ))
 (( insert_file beta_bosh_intro.md ))
 Let's try to deploy now, and see what information still needs to be resolved:
@@ -1077,7 +1081,7 @@ Makefile:22: recipe for target 'manifest' failed
 make: *** [manifest] Error 5
 ```
 
-Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those:
+Oh boy. That's a lot. Cloud Foundry must be complicated. Looks like a lot of the fog_connection properties are all duplicates though, so lets fill out `properties.yml` with those (no need to create the blobstore S3 buckets yourself):
 
 ```
 $ cat properties.yml
@@ -1131,7 +1135,7 @@ $ make deploy
 
 **TODO:** Create the `ccdb`,`uaadb` and `diegodb` databases inside the RDS Instance.
 
-We will manually create uaadb, ccdb and diegodb for now. First, connect to your PostgreSql database using the following command.
+We will manually create uaadb, ccdb and diegodb for now. First, connect to your PostgreSQL database using the following command.
 
 ```
 psql postgres://cfdbadmin:your_password@your_rds_instance_endpoint:5432/postgres
@@ -1195,7 +1199,7 @@ As a quick pre-flight check, run `make manifest` to compile your Terraform plan.
 $ make deploy
 ```
 
-From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add a CNAME record that maps the domain name to the ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
+From here we need to configure our domain to point to the ELB. Different clients may use different DNS servers. No matter which DNS server you are using, you will need add two CNAME records, one that maps the domain-name to the CF-ELB endpoint and one that maps the ssh.domain-name to the CF-SSH-ELB endpoint. In this project, we will set up a Route53 as the DNS server. You can log into the AWS Console, create a new _Hosted Zone_ for your domain. Then go back to the `terraform/aws` sub-directory of this repository and add to the `aws.tfvars` file the following configurations:
 
 ```
 aws_route53_staging_enabled = "1"
@@ -1395,7 +1399,7 @@ meta:
   dns: [10.4.0.2]
   elbs: [xxxxxx-staging-cf-elb] # <- ELB name
   ssh_elbs: [xxxxxx-staging-cf-ssh-elb] # <- SSH ELB name
-  router_security_group: [wide-open]
+  router_security_groups: [wide-open]
   security_groups: [wide-open]
 
 networks:

--- a/walkthrough/beta_cf_cacert.md
+++ b/walkthrough/beta_cf_cacert.md
@@ -18,7 +18,7 @@ Created out/CertAuth.crl
 Then create the certificates for your domain:
 
 ```
-$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.apps.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
+$ certstrap request-cert -common-name *.staging.<your domain> -domain *.system.staging.<your domain>,*.run.staging.<your domain>,*.login.staging.<your domain>,*.uaa.staging.<your domain>
 
 Enter passphrase (empty for no passphrase):
 

--- a/walkthrough/beta_cf_push_app.md
+++ b/walkthrough/beta_cf_push_app.md
@@ -12,7 +12,7 @@ cf target -s test
 
 ```
 
-Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  rego on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
+Once you are in the space, you can push an very simple app [cf-env][cf-env]  to the CF. Clone the [cf-env][cf-env]  repo on your bastion server, then go inside the `cf-env` directory, simply run `cf push` and it will start to upload, stage and run your app.
 
 Your `cf push` command may fail like this:
 

--- a/walkthrough/bolo_test.md
+++ b/walkthrough/bolo_test.md
@@ -3,7 +3,7 @@ ensuring that you get no errors (no output is a good sign).
 
 Then, you can deploy to your BOSH Director via `make deploy`.
 
-Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the Gnossis web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
+Once you've deployed, you can validate the deployment via `bosh deployments`. You should see the bolo deployment. You can find the IP of bolo vm by running `bosh vms` for bolo deployment. In order to visit the [Gnossis](https://github.com/bolo/gnossis) web interface on your `bolo/0` VM from your browser on your laptop, you need to setup port forwarding to enable it.
 
 One way of doing it is using ngrok, go to [ngrok Downloads] [ngrok-download] page and download the right version to your `bolo/0` VM, unzip it and run `./ngrok http 80`, it will output something like this:
 

--- a/walkthrough/concourse_intro.md
+++ b/walkthrough/concourse_intro.md
@@ -52,7 +52,7 @@ Running env setup hook: ~/ops/concourse-deployments/.env_hooks/00_confirm_vault
 
 Use this Vault for storing deployment credentials?  [yes or no] yes
 Running env setup hook: ~/ops/concourse-deployments/.env_hooks/gen_creds
-Generating credentials for Concource CI
+Generating credentials for Concourse CI
 Created environment (( insert_parameter template_name ))/proto:
 ~/ops/concourse-deployments/(( insert_parameter site.name ))/proto
 ├── cloudfoundry.yml

--- a/walkthrough/overview.md
+++ b/walkthrough/overview.md
@@ -6,7 +6,7 @@ generate the underlying cloud infrastructure, then use Terraform to prepare a ba
 host.
 
 From this bastion, we setup a special BOSH Director we call the **proto-BOSH**
-server where software like Vault, Concourse, Bolo and SHEILD are setup in order
+server where software like Vault, Concourse, Bolo and SHIELD are setup in order
 to give each of the environments created after the **proto-BOSH** key benefits of:
 
 * Secure Credential Storage


### PR DESCRIPTION
The aws.md file produced by the script should match the walkthrough, with a few minor exceptions - mostly just a couple instances of text placement that worked better with the new structure, plus a couple more spelling errors.