### PR TITLE
terraform/aws: enable vpc endpoint for internal networks

### DIFF
--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -162,6 +162,11 @@ resource "aws_route_table" "internal" {
   tags { Name = "${var.aws_vpc_name}-internal" }
 }
 
+resource "aws_vpc_endpoint" "internal-s3" {
+  vpc_id       = "${aws_vpc.default.id}"
+  service_name = "com.amazonaws.${var.aws_region}.s3"
+  route_table_ids = ["${aws_route_table.internal.id}"]
+}
 
 
  ######  ##     ## ########  ##    ## ######## ########  ######


### PR DESCRIPTION
By configuring this VPC enpoint it will route traffic from the internal
subnets to S3 via a this "virtual" endpoint. This will offload traffic
from the NAT instance, so it will be less of a bottleneck for the
cluster when there are a lot of interactions between CF and S3.