### PR TITLE
remove container on stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,4 @@ docker-build:
 	docker build -t codex .
 
 docker-run:
-	docker run --name=codex -p 127.0.0.1:8000:8000 -v $${PWD}:/codex codex:latest
-	
+	docker run --rm --name=codex -p 127.0.0.1:8000:8000 -v $${PWD}:/codex codex:latest


### PR DESCRIPTION
Add `--rm` to the run command will ensure that each stopped container (that is named) will be removed.  This way when a user runs `make docker` again, they won't have a collision with a container named `codex`.